### PR TITLE
Codecs refer to types by references instead of raw python types

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 dds --count --select=E9,F63,F7,F82,F821 --show-source --statistics
+        flake8 dds --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 dds --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Typing with mypy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 dds --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 dds --count --select=E9,F63,F7,F82,F821 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 dds --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Typing with mypy

--- a/dds/codec.py
+++ b/dds/codec.py
@@ -50,12 +50,15 @@ class CodecRegistry(object):
 def _build_default_registry() -> CodecRegistry:
     codecs: List[CodecProtocol] = []
     if importlib.util.find_spec("pandas") is not None:
+        # TODO: this could be done without hardcoding pandas, simply by loading at the
+        # name of the head module in the list of supported types.
         from .codecs.pandas import PandasLocalCodec
 
         _logger.info(f"Loading pandas codecs")
         codecs.append(PandasLocalCodec())
     else:
         _logger.debug(f"Cannot load pandas")
+    # To prevent a circular import.
     from .codecs.builtins import StringLocalCodec, PickleLocalCodec
 
     # Put the default codecs at the bottom of the list:

--- a/dds/codec.py
+++ b/dds/codec.py
@@ -1,9 +1,9 @@
 import importlib.util
 import logging
-from typing import Optional, Dict, List, Type, Any
+from typing import Optional, Dict, List, Type, Any, Union
 
-from .codecs.builtins import StringLocalCodec, PickleLocalCodec
-from .structures import KSException, CodecProtocol, ProtocolRef
+from .structures import KSException, CodecProtocol, ProtocolRef, SupportedType
+from .structures_utils import SupportedTypeUtils
 
 _logger = logging.getLogger(__name__)
 
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 class CodecRegistry(object):
     def __init__(self, codecs: List[CodecProtocol]):
         self.codecs = list(codecs)
-        self._handled_types: Dict[Type[Any], CodecProtocol] = {}
+        self._handled_types: Dict[SupportedType, CodecProtocol] = {}
         self._protocols: Dict[ProtocolRef, CodecProtocol] = {}
         for c in codecs:
             self.add_codec(c)
@@ -25,7 +25,7 @@ class CodecRegistry(object):
 
     # TODO: add the location too.
     def get_codec(
-        self, obj_type: Optional[Type[Any]], ref: Optional[ProtocolRef]
+        self, obj_type: Union[SupportedType, None], ref: Optional[ProtocolRef]
     ) -> CodecProtocol:
         # First the reference
         if ref:
@@ -33,9 +33,12 @@ class CodecRegistry(object):
                 raise KSException(f"Requested protocol {ref}, which is not registered")
             return self._protocols[ref]
         # Then the object type
-        if obj_type:
+        if obj_type is not None:
             # Try to use object as backup
-            cp = self._handled_types.get(obj_type) or self._handled_types.get(object)
+            pref: SupportedType = obj_type
+            cp = self._handled_types.get(pref) or self._handled_types.get(
+                SupportedTypeUtils.from_type(object)
+            )
             if cp is None:
                 raise KSException(
                     f"Requested protocol for type {obj_type}, which is not registered"
@@ -53,6 +56,8 @@ def _build_default_registry() -> CodecRegistry:
         codecs.append(PandasLocalCodec())
     else:
         _logger.debug(f"Cannot load pandas")
+    from .codecs.builtins import StringLocalCodec, PickleLocalCodec
+
     # Put the default codecs at the bottom of the list:
     codecs.append(StringLocalCodec())
     codecs.append(PickleLocalCodec())

--- a/dds/codec.py
+++ b/dds/codec.py
@@ -1,6 +1,6 @@
 import importlib.util
 import logging
-from typing import Optional, Dict, List, Type, Any, Union
+from typing import Optional, Dict, List, Union
 
 from .structures import KSException, CodecProtocol, ProtocolRef, SupportedType
 from .structures_utils import SupportedTypeUtils

--- a/dds/codecs/__init__.py
+++ b/dds/codecs/__init__.py
@@ -1,0 +1,1 @@
+from . import builtins, databricks, pandas

--- a/dds/codecs/builtins.py
+++ b/dds/codecs/builtins.py
@@ -38,7 +38,7 @@ class PickleLocalCodec(CodecProtocol):
         return ProtocolRef("builtins.pickle")
 
     def handled_types(self) -> List[SupportedType]:
-        return [STU.from_type(o) for o in [object, type(None)]]
+        return [STU.from_type(type(None)), SupportedType("object")]
 
     def serialize_into(self, blob: Any, loc: GenericLocation) -> None:
         with open(loc, "wb") as f:

--- a/dds/codecs/builtins.py
+++ b/dds/codecs/builtins.py
@@ -2,14 +2,16 @@
 The string protocol.
 """
 import pickle
-from typing import Any
+from typing import Any, List
 
 from ..structures import (
     CodecProtocol,
     ProtocolRef,
     GenericLocation,
     CodecBackend,
+    SupportedType,
 )
+from ..structures_utils import SupportedTypeUtils as STU
 
 Local = CodecBackend("Local")
 
@@ -18,8 +20,8 @@ class StringLocalCodec(CodecProtocol):
     def ref(self):
         return ProtocolRef("default.string")
 
-    def handled_types(self):
-        return [str]
+    def handled_types(self) -> List[SupportedType]:
+        return [STU.from_type(str)]
 
     def serialize_into(self, blob: str, loc: GenericLocation) -> None:
         assert isinstance(blob, str)
@@ -35,8 +37,8 @@ class PickleLocalCodec(CodecProtocol):
     def ref(self):
         return ProtocolRef("builtins.pickle")
 
-    def handled_types(self):
-        return [object, type(None)]
+    def handled_types(self) -> List[SupportedType]:
+        return [STU.from_type(o) for o in [object, type(None)]]
 
     def serialize_into(self, blob: Any, loc: GenericLocation) -> None:
         with open(loc, "wb") as f:

--- a/dds/codecs/pandas.py
+++ b/dds/codecs/pandas.py
@@ -5,14 +5,14 @@ It relies on pandas having a parquet driver installed (which may or may not be t
 """
 
 import logging
+from typing import Any
 
-# TODO: optimize the structure so that there is no need to load it until the
-# last moment, if possible.
-
-import pandas.core.frame
-
-from ..structures import CodecProtocol, ProtocolRef, GenericLocation
-from .builtins import Local
+from ..structures import (
+    CodecProtocol,
+    ProtocolRef,
+    GenericLocation,
+    SupportedType as ST,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -21,17 +21,17 @@ class PandasLocalCodec(CodecProtocol):
     def ref(self):
         return ProtocolRef("default.pandas_local")
 
-    def handled_backends(self):
-        return [Local]
-
-    # TODO: just use strings, it will be faster
     def handled_types(self):
-        return [pandas.DataFrame, pandas.core.frame.DataFrame]
+        return [ST("pandas.DataFrame"), ST("pandas.core.frame.DataFrame")]
 
-    def serialize_into(self, blob: pandas.DataFrame, loc: GenericLocation):
+    def serialize_into(self, blob: Any, loc: GenericLocation):
+        import pandas
+
         assert isinstance(blob, pandas.DataFrame)
         blob.to_parquet(loc)
         _logger.debug(f"Committed dataframe to parquet: {loc}")
 
-    def deserialize_from(self, loc: GenericLocation) -> pandas.DataFrame:
+    def deserialize_from(self, loc: GenericLocation) -> "pandas.DataFrame":
+        import pandas
+
         return pandas.read_parquet(loc)

--- a/dds/store.py
+++ b/dds/store.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from .codec import codec_registry
 from .structures import PyHash, DDSPath, KSException, GenericLocation, ProtocolRef
+from .structures_utils import SupportedTypeUtils as STU
 
 _logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ class LocalFileStore(Store):
     def store_blob(
         self, key: PyHash, blob: Any, codec: Optional[ProtocolRef] = None
     ) -> None:
-        protocol = codec_registry().get_codec(type(blob), codec)
+        protocol = codec_registry().get_codec(STU.from_type(type(blob)), codec)
         p = os.path.join(self._root, "blobs", key)
         protocol.serialize_into(blob, GenericLocation(p))
         meta_p = os.path.join(self._root, "blobs", key + ".meta")

--- a/dds/structures.py
+++ b/dds/structures.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
+from enum import Enum
 from functools import total_ordering
 from pathlib import PurePosixPath
-from typing import Any, NewType, NamedTuple, Optional, Dict, List, Type, Tuple
-from enum import Enum
+from typing import Any, NewType, NamedTuple, Optional, Dict, List, Tuple
 
 
 class ProcessingStage(str, Enum):

--- a/dds/structures.py
+++ b/dds/structures.py
@@ -62,12 +62,14 @@ GenericLocation = NewType("GenericLocation", str)
 
 CodecBackend = NewType("CodecBackend", str)
 
+SupportedType = NewType("SupportedType", str)
+
 
 class CodecProtocol(object):
     def ref(self) -> ProtocolRef:
         pass
 
-    def handled_types(self) -> List[Type[Any]]:
+    def handled_types(self) -> List[SupportedType]:
         """ The list of types that this codec can handle """
         pass
 

--- a/dds/structures_utils.py
+++ b/dds/structures_utils.py
@@ -15,6 +15,7 @@ from .structures import (
     PyHash,
     LocalDepPath,
     FunctionIndirectInteractions,
+    SupportedType,
 )
 
 _logger = logging.getLogger(__name__)
@@ -166,3 +167,9 @@ class FunctionIndirectInteractionUtils(object):
             if isinstance(fis0, FunctionIndirectInteractions):
                 res.update(list(FunctionIndirectInteractionUtils.all_stores(fis0)))
         return res
+
+
+class SupportedTypeUtils(object):
+    @staticmethod
+    def from_type(t: type) -> SupportedType:
+        return SupportedType(str(t.__name__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 description-file = README.md
 
 [flake8]
-ignore = W292, W391, E111, E114, W504, W503, E501, F541, C901
+ignore = W292, W391, E111, E114, W504, W503, E501, F541, C901, F821, W293
 max-line-length = 120
 exclude = tests/*
 max-complexity = 10


### PR DESCRIPTION
This means that the modules do not need to be imported, leading to much faster loading times.