### PR TITLE
[133] Considering higher order functions that are passed as variables

### DIFF
--- a/dds/_api.py
+++ b/dds/_api.py
@@ -287,8 +287,8 @@ def _eval_new_ctx(
             start_globals=local_vars,
             resolved_references=OrderedDict(),
         )
-        _logger.debug(f"_eval_new_ctx: introspect_indirect completed")
         inters_indirect = introspect_indirect(fun, eval_ctx)
+        _logger.debug(f"_eval_new_ctx: introspect_indirect completed")
         all_loads = FunctionIndirectInteractionUtils.all_loads(inters_indirect)
         all_stores = FunctionIndirectInteractionUtils.all_stores(inters_indirect)
         loads_to_check = sorted([p for p in all_loads if p not in all_stores])

--- a/dds/_introspect_indirect.py
+++ b/dds/_introspect_indirect.py
@@ -182,11 +182,11 @@ class InspectFunctionIndirect(object):
         local_vars = set(
             InspectFunction.get_local_vars(body, dummy_arg_ctx, fun_path) + arg_names
         )
-        _logger.debug(f"inspect_fun: %s local_vars: %s", fun_path, local_vars)
+        # _logger.debug(f"inspect_fun: %s local_vars: %s", fun_path, local_vars)
         vdeps = ExternalVarsVisitor(mod, gctx, local_vars)
         for n in body:
             vdeps.visit(n)
-        _logger.debug(f"inspect_fun: %s ExternalVarsVisitor: %s", fun_path, vdeps.vars)
+        # _logger.debug(f"inspect_fun: %s ExternalVarsVisitor: %s", fun_path, vdeps.vars)
         calls_v = IntroVisitorIndirect(mod, gctx, local_vars, call_stack, fun_path)
         for n in body:
             calls_v.visit(n)
@@ -414,7 +414,7 @@ class IntroVisitorIndirect(ast.NodeVisitor):
             # by directly importing the function.
             if isinstance(obj, (FunctionType,)):
                 # Building a fake AST node to handle functions called without arguments. They may not
-                _logger.debug(f"visit_name: {node} {pformat(node)} {self._store_names}")
+                # _logger.debug(f"visit_name: {node} {pformat(node)} {self._store_names}")
                 # No arg given
                 call_node = ast.Call(
                     func=node, args=[], keywords=[], starargs=None, kwargs=None

--- a/dds/_introspect_indirect.py
+++ b/dds/_introspect_indirect.py
@@ -29,6 +29,8 @@ from .introspect import (
     ExternalVarsVisitor,
     LocalVar,
     _function_name,
+    get_assign_targets,
+    python_builtin_names,
 )
 from .structures import (
     FunctionArgContext,
@@ -180,11 +182,12 @@ class InspectFunctionIndirect(object):
         local_vars = set(
             InspectFunction.get_local_vars(body, dummy_arg_ctx, fun_path) + arg_names
         )
-        # _logger.debug(f"inspect_fun: %s local_vars: %s", fun_path, local_vars)
+        _logger.debug(f"inspect_fun: %s local_vars: %s", fun_path, local_vars)
         vdeps = ExternalVarsVisitor(mod, gctx, local_vars)
         for n in body:
             vdeps.visit(n)
-        calls_v = IntroVisitorIndirect(mod, gctx, local_vars, call_stack)
+        _logger.debug(f"inspect_fun: %s ExternalVarsVisitor: %s", fun_path, vdeps.vars)
+        calls_v = IntroVisitorIndirect(mod, gctx, local_vars, call_stack, fun_path)
         for n in body:
             calls_v.visit(n)
 
@@ -358,11 +361,14 @@ class IntroVisitorIndirect(ast.NodeVisitor):
         gctx: EvalMainContext,
         function_var_names: Set[LocalVar],
         call_stack: List[CanonicalPath],
+        fun_path: CanonicalPath,
     ):
+        current_fun_name = LocalVar(CPU.last(fun_path))
         # TODO: start_mod is in the global context
         self._start_mod = start_mod
         self._gctx = gctx
         self._function_var_names = set(function_var_names)
+        self._store_names: Set[LocalVar] = {current_fun_name}
         self._call_stack = call_stack
         # All the calls to a load and subsequent function calls, ordered
         self.results: List[Union[FunctionIndirectInteractions, DDSPath]] = []
@@ -380,4 +386,47 @@ class IntroVisitorIndirect(ast.NodeVisitor):
         )
         if fi_or_p is not None:
             self.results.append(fi_or_p)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> Any:
+        targets = get_assign_targets(node)
+        if targets:
+            self._store_names.update(targets)
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> Any:
+        # Look at names of variables that are names imported in the context of the function (in the module) but that are
+        # not builtins.
+        # This neglects the case of shadowing within the function: if the function has a variable that has the same name
+        # as another function, then a mismatch will happen.
+        if (
+            node.id in self._start_mod.__dict__
+            and node.id not in python_builtin_names
+            and LocalVar(node.id) not in self._function_var_names
+            and LocalVar(node.id) not in self._store_names
+        ):
+            # Quick check that it is indeed a function or a module:
+            # TODO: add a test for modules
+            obj = self._start_mod.__dict__[node.id]
+            self._store_names.add(LocalVar(node.id))
+            # Just handling functions, not modules.
+            # Handling modules is more complicated (requires tracing the full call) and it can be easily worked around
+            # by directly importing the function.
+            if isinstance(obj, (FunctionType,)):
+                # Building a fake AST node to handle functions called without arguments. They may not
+                _logger.debug(f"visit_name: {node} {pformat(node)} {self._store_names}")
+                # No arg given
+                call_node = ast.Call(
+                    func=node, args=[], keywords=[], starargs=None, kwargs=None
+                )
+                fi_or_p = InspectFunctionIndirect.inspect_call(
+                    call_node,
+                    self._gctx,
+                    self._start_mod,
+                    self._function_var_names,
+                    self._call_stack,
+                )
+                if fi_or_p is not None:
+                    self.results.append(fi_or_p)
+
         self.generic_visit(node)

--- a/dds/introspect.py
+++ b/dds/introspect.py
@@ -100,11 +100,12 @@ def get_assign_targets(node: Any) -> List[LocalVar]:
         type(node),
         node,
     )
-    # For now putting an exception, but it should be flag configurable.
-    raise DDSException(
-        f"Expected assignment object to be of type Tuple or Name in AST, got {type(node)}: {pformat(node)}",
-        error_code=DDSErrorCode.UNKNOWN_AST_NODE,
-    )
+    return []
+    # TODO: configurable behaviour about such issues. It is indicative of an issue in most cases.
+    # raise DDSException(
+    #     f"Expected assignment object to be of type Tuple or Name in AST, got {type(node)}: {pformat(node)}",
+    #     error_code=DDSErrorCode.UNKNOWN_AST_NODE,
+    # )
 
 
 def _fis_to_siglist(fis: List[FunctionInteractions]) -> List[Tuple[HK, PyHash]]:

--- a/dds/structures_utils.py
+++ b/dds/structures_utils.py
@@ -71,7 +71,7 @@ class FunctionInteractionsUtils(object):
         """
         Returns a list of paths that are terminal but also with leaves (for example: [/f, /f/g] -> [/f]).
         """
-        _logger.debug("non_terminal in: %s %s", paths, current_prefix)
+        # _logger.debug("non_terminal in: %s %s", paths, current_prefix)
         empty_path = DDSPath("/")
         res: List[DDSPath] = []
         non_empty_paths = [p for p in paths if p != empty_path]
@@ -81,11 +81,11 @@ class FunctionInteractionsUtils(object):
             res.append(current_prefix)
 
         splits = [DDSPathUtils.split(p) for p in non_empty_paths]
-        _logger.debug("non_terminal splits: %s", splits)
+        # _logger.debug("non_terminal splits: %s", splits)
         groups = itertools.groupby(splits, lambda x: x[0])
         for (key, l) in groups:
             sub: List[DDSPath] = [(p if p is not None else empty_path) for (_, p) in l]
-            _logger.debug("non_terminal: %s %s", key, sub)
+            # _logger.debug("non_terminal: %s %s", key, sub)
             sub_path: DDSPath = DDSPath(
                 "/" + key
             ) if current_prefix is None else DDSPath(current_prefix + "/" + key)
@@ -239,6 +239,10 @@ class CanonicalPathUtils(object):
     @staticmethod
     def head(p: CanonicalPath) -> str:
         return p._path.parts[0]
+
+    @staticmethod
+    def last(p: CanonicalPath) -> str:
+        return p._path.parts[-1]
 
     @staticmethod
     def tail(p: CanonicalPath) -> CanonicalPath:

--- a/dds_tests/test_higher_order.py
+++ b/dds_tests/test_higher_order.py
@@ -21,7 +21,7 @@ def f():
 
 
 @pytest.mark.usefixtures("cleandir")
-def test_gh133():
+def test_gh133_1():
     global x
     assert f() == [1, 2]
     assert _c.value == 2

--- a/dds_tests/test_higher_order.py
+++ b/dds_tests/test_higher_order.py
@@ -1,0 +1,32 @@
+import dds
+import pytest
+import pathlib
+from .utils import cleandir, Counter, spath
+
+_ = cleandir
+
+_c = Counter()
+
+x = 1
+
+
+def g(i):
+    _c.increment()
+    return i + x
+
+
+@dds.data_function("/f")
+def f():
+    return list(map(g, range(2)))
+
+
+@pytest.mark.usefixtures("cleandir")
+def test_gh133():
+    global x
+    assert f() == [1, 2]
+    assert _c.value == 2
+    assert f() == [1, 2]
+    assert _c.value == 2
+    x = 2
+    assert f() == [2, 3]
+    assert _c.value == 4


### PR DESCRIPTION
Closes #133 

This is a rough implementation that adds basic support for functions passed by name instead of being called. This solves the most pressing problem of not considering these functions at all. It still has some unaddressed corner cases:
* static functions
* functions called through a module (`mod.f`). This would require a bigger refactoring in a complex section of the code.